### PR TITLE
[Hotfix] - Remove deliver after from ready_for_delivery scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,23 @@
-source "http://rubygems.org"
+source 'http://rubygems.org'
 
 # Declare your gem's dependencies in push.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 gemspec
 
+gem 'activerecord', require: 'active_record'
+gem 'database_cleaner'
+gem 'mysql2'
+gem 'pg'
 gem 'rake'
 gem 'rspec'
 gem 'shoulda'
-gem 'activerecord', :require => 'active_record'
-gem 'pg'
-gem 'mysql2'
-gem 'sqlite3'
-gem 'database_cleaner'
 gem 'simplecov'
+gem 'sqlite3'
 
 group :development do
+  gem 'growl'
   gem 'guard'
   gem 'guard-rspec'
-  gem 'growl'
   gem 'webmock'
 end

--- a/lib/push/message.rb
+++ b/lib/push/message.rb
@@ -11,7 +11,7 @@ module Push
     validates :device, presence: true
 
     scope :ready_for_delivery, -> {
-      where('delivered = ? AND failed = ? )', false, false)
+      where('delivered = ? AND failed = ?', false, false)
     }
 
     def deliver(connection)

--- a/lib/push/message.rb
+++ b/lib/push/message.rb
@@ -1,31 +1,34 @@
 require 'active_record'
 require 'active_record/errors'
 require 'push/daemon/database_reconnectable'
+
 module Push
   class Message < ActiveRecord::Base
     include Push::Daemon::DatabaseReconnectable
-    self.table_name = "push_messages"
+    self.table_name = 'push_messages'
 
-    validates :app, :presence => true
-    validates :device, :presence => true
+    validates :app, presence: true
+    validates :device, presence: true
 
-    scope :ready_for_delivery, -> { where('delivered = ? AND failed = ? AND (deliver_after IS NULL OR deliver_after < ?)', false, false, Time.now) }
+    scope :ready_for_delivery, -> {
+      where('delivered = ? AND failed = ? )', false, false)
+    }
 
     def deliver(connection)
       begin
-        connection.write(self.to_message)
+        connection.write(to_message)
         check_for_error(connection)
 
         # this makes no sense in the rails environment, but it does in the daemon
         with_database_reconnect_and_retry(connection.name) do
           self.delivered = true
           self.delivered_at = Time.now
-          self.save!(:validate => false)
+          save!(validate: false)
         end
 
         Push::Daemon.logger.info("[#{connection.name}] Message #{id} delivered to #{device}")
-      rescue Push::DeliveryError, Push::DisconnectionError => error
-        handle_delivery_error(error, connection)
+      rescue Push::DeliveryError, Push::DisconnectionError => e
+        handle_delivery_error(e, connection)
         raise
       end
     end
@@ -41,7 +44,7 @@ module Push
         self.failed_at = Time.now
         self.error_code = error.code
         self.error_description = error.description
-        self.save!(:validate => false)
+        save!(validate: false)
       end
     end
   end


### PR DESCRIPTION
## Description

Just a minor hotfix to remove the use of deliver_after since we don't use it on our platform.